### PR TITLE
Add vercel.json rewrite rules for SPA routing support

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -3,22 +3,27 @@ import React, { createContext, useContext, useState, useEffect } from 'react';
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
-    const [user, setUser] = useState(null);
-    const [loading, setLoading] = useState(true);
+    // 💡 CAMBIO CLAVE: Inicializamos el estado directamente desde localStorage
+    // Esto ocurre INSTANTÁNEAMENTE antes de que React renderice nada.
+    const [user, setUser] = useState(() => {
+        const savedUser = localStorage.getItem('tm_user');
+        return savedUser ? JSON.parse(savedUser) : null;
+    });
+
+    // Si ya encontramos al usuario arriba, no necesitamos mostrar un "cargando"
+    const [loading, setLoading] = useState(false);
 
     useEffect(() => {
+        // Mantenemos esto por si necesitas validar el token con el servidor al cargar
         const savedUser = localStorage.getItem('tm_user');
-        // El token se guarda por separado para que el apiClient lo encuentre
         if (savedUser) {
             setUser(JSON.parse(savedUser));
         }
         setLoading(false);
     }, []);
 
-    // 👈 ACTUALIZADO: Ahora recibe el token de Railway
     const login = (email, token) => {
         const username = email.split('@')[0];
-
         const userData = {
             username: username,
             email: email,
@@ -26,16 +31,14 @@ export const AuthProvider = ({ children }) => {
         };
 
         setUser(userData);
-        // Guardamos el objeto de usuario para la UI
         localStorage.setItem('tm_user', JSON.stringify(userData));
-        // 👈 CLAVE: Guardamos el token exacto que pide el apiClient
         localStorage.setItem('token', token);
     };
 
     const logout = () => {
         setUser(null);
         localStorage.removeItem('tm_user');
-        localStorage.removeItem('token'); // 👈 Limpieza total
+        localStorage.removeItem('token');
     };
 
     return (

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+        {
+            "source": "/((?!api).*)",
+            "destination": "/index.html"
+        }
+    ]
+}


### PR DESCRIPTION
Summary of Changes:

Added vercel.json configuration: Implemented rewrite rules to support Single Page Application (SPA) routing, resolving 404 errors when refreshing the browser on internal routes.

Refactored AuthContext state initialization: Updated the authentication state to read from localStorage synchronously. This prevents accidental redirects to the /login page by ensuring the user session is recognized immediately during the component mounting lifecycle.

Verified Session Persistence: Confirmed that private routes now correctly maintain an active session after a manual browser refresh.